### PR TITLE
Update checkout action to v7

### DIFF
--- a/.github/workflows/basic_build.yml
+++ b/.github/workflows/basic_build.yml
@@ -41,7 +41,7 @@ jobs:
 
     steps:
     # Checkout, fetch-depth=0 fetches the full repos (required for automatic versioning to work)
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 0
         submodules: true

--- a/.github/workflows/basic_release.yml
+++ b/.github/workflows/basic_release.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         submodules: true
 

--- a/.github/workflows/build_and_push_to_docker_hub.yml
+++ b/.github/workflows/build_and_push_to_docker_hub.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Log in to Docker Hub
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9

--- a/.github/workflows/read_build_targets.yml
+++ b/.github/workflows/read_build_targets.yml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
     - name: Checkout Repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7
       with:
         submodules: false
 


### PR DESCRIPTION
Node 20, which actions/checkout@v4 targets, is being deprecated on GitHub Actions runners. Bump straight to the latest major (v7) rather than the Node-24 minimum (v5) to avoid a second bump shortly after.

Analysis shows breaking changes have no effects here.