### PR TITLE
Set up dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Dependabot is a first-party tool from Github to keep versions up-to-date. In this case,
Github action versions. See more here: [Dependabot version updates on Github Docs](https://docs.github.com/en/code-security/concepts/supply-chain-security/dependabot-version-updates)

## Problems Dependabot solves

Using old versions of Github actions has several costs:

**Security**: an action pinned to an old SHA/tag keeps running even after upstream ships
a fix for a vulnerability in it.

**Drift**: over time, workflows across repos end up pinned to different versions of the
same action for no reason other than whoever touched the file last, making CI behavior
inconsistent and harder to reason about.

**Function**: Updates introduces new functionality and performance enhancements.

## What Dependabot does

Dependabot is a GitHub-native bot that watches the dependencies declared in a repo and
opens PRs when newer versions are available — you review and merge like any other PR,
nothing is applied automatically.

It's configured via a `.github/dependabot.yml` file per repo, one entry per "ecosystem"
(e.g. `github-actions`, `npm`, `pip`, `docker`). For us, that means it watches the
`uses:` lines in `.github/workflows/*.yml` — action versions like `actions/checkout@v7`
and the SHA-pinned Docker actions — and files a PR bumping them when a new release
ships.

The same mechanism covers reusable-workflow references: `crazyflie-firmware`'s
`uses: bitcraze/workflows/.github/workflows/...@<sha>` is just another
`github-actions`-ecosystem dependency, so once `bitcraze/workflows` cuts a new
commit/tag on that file, Dependabot proposes bumping the pinned ref in
`crazyflie-firmware` too.

It does not understand git submodules or pixi, so those stay unmanaged.

## Activation only happens on the default branch

Dependabot reads `.github/dependabot.yml` only as it exists on the repo's **default
branch** (`main`/`master`). Adding the file on a feature branch doesn't start anything
— opening a PR from that branch just gets a YAML-syntax validation check, not a live
dependency scan. The weekly schedule only kicks in once the file is merged into the
default branch. Separately, each `updates` entry can set `target-branch` to control
which branch Dependabot opens its update PRs *against* — that's unrelated to where the
config file itself needs to live to be picked up.

So, we can only verify after merging this PR.

## Verification plan

- **Prerequisite**: Dependabot version updates only read `dependabot.yml` from the
  **default branch** (`master` for crazyflie-firmware, `main` for workflows).
- **Syntax**: GitHub validates `dependabot.yml` on push; a malformed file shows as an error
  banner on the repo's Insights > Dependency graph > Dependabot page instead of silently
  doing nothing.
- **Registration**: after merging to the default branch, open repo Settings > Advanced
  security > Dependabot and confirm "Dependabot version updates" shows as
  configured/enabled for both repos.
- **Manual trigger**: on the Insights > Dependency graph > Dependabot page, use "Last
  checked ... Check for updates" to force an immediate run rather than waiting a week,
  and confirm it completes without error.
- **Behavior check**: since `crazyflie-firmware`'s `read_build_targets.yml` call is
  currently pinned to a raw SHA (see Findings), a successful first run should surface a
  proposed PR updating that pin — confirms Dependabot is actually parsing the `uses:`
  lines, not just accepting the config.